### PR TITLE
Hotfix/47 メモの削除処理を修正しました。

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -442,6 +442,28 @@ ipcMain.handle('load-scraps-from-json', async () => {
   return scrapsStore.get('scraps', null);
 });
 
+/**
+ * scraps.jsonから指定したデータを削除する
+ */
+ipcMain.handle('delete-scrap', async (_event, targetId) => {
+  const settingStore = await getSettingStore();
+  const projectPath = await settingStore.get('projectPath', null);
+  if (!projectPath) {
+    console.warn('Project path is not set');
+    return null;
+  }
+  const scrapsStore = new Store({
+    name: 'scraps',
+    cwd: projectPath,
+  });
+  // 既存の scraps を取得
+  const scraps = scrapsStore.get('scraps', []) as any[];
+
+  // IDが一致しないものだけ残す
+  const updatedScraps = scraps.filter((scrap) => scrap.id !== targetId);
+  return scrapsStore.set('scraps', updatedScraps);
+});
+
 // ファイル操作 IPC
 ipcMain.handle('open-file', openFile);
 ipcMain.handle('save-file', saveFile);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -315,6 +315,18 @@ ipcMain.handle('rename', async (_event, oldPath: string, newPath: string) => {
 });
 
 /**
+ * ファイルを削除する
+ */
+ipcMain.handle('delete', async (_event, filePath: string) => {
+  try {
+    await fs.promises.unlink(filePath);
+    return true;
+  } catch (error) {
+    console.error('ファイル削除失敗:', error);
+    return false;
+  }
+});
+/**
  * メモの情報を管理用JSON(scraps.json)に保存する
  */
 ipcMain.handle('save-scrap-json', async (_event, data) => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -56,6 +56,14 @@ const api = {
     async rename(oldPath: string, newPath: string): Promise<boolean> {
       return await ipcRenderer.invoke('rename', oldPath, newPath);
     },
+    /**
+     * ファイルを削除します。
+     * @param filePath 削除対象のファイル名を含む絶対パス
+     * @returns ファイル削除に成功すればtrue、失敗すればfalse
+     */
+    async delete(filePath: string): Promise<boolean> {
+      return await ipcRenderer.invoke('delete', filepath);
+    },
   },
 
   scrap: {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -110,6 +110,14 @@ const api = {
     async getTitle(id: string): Promise<string> {
       return await ipcRenderer.invoke('get-title', id);
     },
+    /**
+     * scraps.jsonからメモを削除します。
+     * @params id
+     * @return 削除が成功 true、失敗 false
+     */
+    async deleteScrap(id: string): Promise<boolean> {
+      return await ipcRenderer.invoke('delete-scrap', id);
+    },
   },
 
   project: {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -62,7 +62,7 @@ const api = {
      * @returns ファイル削除に成功すればtrue、失敗すればfalse
      */
     async delete(filePath: string): Promise<boolean> {
-      return await ipcRenderer.invoke('delete', filepath);
+      return await ipcRenderer.invoke('delete', filePath);
     },
   },
 

--- a/src/renderer/src/model/ScrapModel.ts
+++ b/src/renderer/src/model/ScrapModel.ts
@@ -62,6 +62,13 @@ class ScrapModel {
   setOrder(order: number): void {
     this.order = order;
   }
+  /**
+   * Markdownファイルを削除する
+   */
+  async deleteFile(projectPath: string): Promise<void> {
+    const filePath = `${projectPath}/${this.title}.md`;
+    await window.api.file.delete(filePath);
+  }
 }
 
 export default ScrapModel;

--- a/src/renderer/src/viewmodel/ScrapViewModel.ts
+++ b/src/renderer/src/viewmodel/ScrapViewModel.ts
@@ -247,8 +247,15 @@ export const useScrapViewModel = (): {
    * メモの削除
    */
   const deleteScrap = useCallback(
-    (id: number) => {
+    async (id: number) => {
+      const projectPath = await window.api.project.getPath();
+
       setScraps((prevScraps) => {
+        const scrapToDelete = prevScraps.find((s) => s.id === id);
+        if (scrapToDelete) {
+          scrapToDelete.deleteFile(projectPath);
+        }
+
         const filtered = prevScraps.filter((scrap) => scrap.id !== id);
         if (filtered.length > 0 && id === selectedScrapId) {
           setSelectedScrapId(filtered[0].id);

--- a/src/renderer/src/viewmodel/ScrapViewModel.ts
+++ b/src/renderer/src/viewmodel/ScrapViewModel.ts
@@ -249,11 +249,13 @@ export const useScrapViewModel = (): {
   const deleteScrap = useCallback(
     async (id: number) => {
       const projectPath = await window.api.project.getPath();
-
       setScraps((prevScraps) => {
         const scrapToDelete = prevScraps.find((s) => s.id === id);
         if (scrapToDelete) {
+          // プロジェクトパスからファイル削除
           scrapToDelete.deleteFile(projectPath);
+          // scraps.jsonからメモ情報を削除
+          window.api.scrap.deleteScrap(id);
         }
 
         const filtered = prevScraps.filter((scrap) => scrap.id !== id);


### PR DESCRIPTION
メモの削除ボタンをクリックすることで、ローカルからもファイルを削除するように修正しました。
scraps.jsonからも対象のメモの情報を削除するように修正しました。