### PR TITLE
feat: Markdownエディタに画像表示機能を追加 (Issue #87)

### DIFF
--- a/src/preload/preload.d.ts
+++ b/src/preload/preload.d.ts
@@ -52,6 +52,10 @@ declare global {
         openFile(): Promise<{ filePath: string; canceled: boolean }>;
         openFolder(): Promise<{ folderPath: string; canceled: boolean }>;
       };
+      image: {
+        save(buffer: Uint8Array, filename: string): Promise<string>;
+        resolvePath(relativePath: string): Promise<string>;
+      };
     };
   }
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -298,6 +298,27 @@ const api = {
       return await ipcRenderer.invoke('open-dialog-folder');
     },
   },
+
+  image: {
+    /**
+     * 画像ファイルを保存します。
+     * @param buffer 画像データ (Uint8Array)
+     * @param filename ファイル名
+     * @returns プロジェクトルートからの相対パス (例: /img/image.png)
+     */
+    async save(buffer: Uint8Array, filename: string): Promise<string> {
+      return await ipcRenderer.invoke('save-image', buffer, filename);
+    },
+
+    /**
+     * プロジェクト相対パスから絶対パスを取得します。
+     * @param relativePath プロジェクトルートからの相対パス (例: /img/image.png)
+     * @returns 絶対パス
+     */
+    async resolvePath(relativePath: string): Promise<string> {
+      return await ipcRenderer.invoke('resolve-image-path', relativePath);
+    },
+  },
 };
 
 // グローバルな `api` 名前空間として、各種機能をレンダラープロセスに公開


### PR DESCRIPTION
## 概要
Issue #87 の実装です。Markdownエディタに画像をドラッグ&ドロップまたはクリップボードから貼り付けできるようにしました。

## 変更内容
- ✅ プロジェクト配下にimgフォルダを自動作成し、画像を保存
- ✅ Markdownエディタへのドラッグ&ドロップで画像を貼り付け
- ✅ クリップボードからcmd+vで画像を貼り付け
- ✅ 画像のMarkdownリンクを自動生成（プロジェクトルートからの相対パス）
- ✅ ファイル名の重複を避けるためにタイムスタンプを追加

## 実装詳細

### Main Process (src/main/index.ts)
- `save-image`: 画像ファイルをプロジェクトの`img`フォルダに保存し、相対パスを返す
- `resolve-image-path`: 相対パスから絶対パスを解決（将来の画像表示用）

### Preload (src/preload/preload.ts, preload.d.ts)
- `window.api.image.save()`: 画像保存API
- `window.api.image.resolvePath()`: パス解決API
- TypeScript型定義を追加

### Renderer (src/renderer/src/components/MarkdownEditor.tsx)
- CodeMirrorのドラッグ&ドロップイベントハンドラを追加
- クリップボードペーストイベントハンドラを追加
- 画像ファイルを自動的にimgフォルダに保存
- Markdownリンク形式でカーソル位置に挿入（例: `![image.png](/img/image_1234567890.png)`）

## 動作確認方法
1. LoreNoteを起動
2. メモを作成または選択
3. 以下のいずれかの方法で画像を貼り付け：
   - 画像ファイルをMarkdownエディタにドラッグ&ドロップ
   - 画像をコピーして、エディタ上でcmd+v (macOS) / ctrl+v (Windows)
4. プロジェクトフォルダ内に`img`フォルダが作成され、画像が保存されることを確認
5. Markdownリンクが自動挿入されることを確認

## 備考
- 画像ファイル名には自動的にタイムスタンプが付与され、重複を防ぎます
- 保存される画像はプロジェクトフォルダの`img`サブフォルダに格納されます
- Markdownリンクはプロジェクトルートからの相対パス形式です

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)